### PR TITLE
0.9.5 hotfix

### DIFF
--- a/man/par_make_h3.Rd
+++ b/man/par_make_h3.Rd
@@ -4,12 +4,12 @@
 \alias{par_make_h3}
 \title{Convert H3 indices to sf object}
 \usage{
-par_make_h3(x, res = 10L)
+par_make_h3(x, res = 5L)
 }
 \arguments{
 \item{x}{sf object.}
 
-\item{res}{integer(1). H3 resolution. Default is 10L.}
+\item{res}{integer(1). H3 resolution. Default is 5L.}
 }
 \value{
 An \code{sf} object with polygons representing the H3 indices.
@@ -31,7 +31,7 @@ nc <- st_transform(nc, "EPSG:4326")
 nc_comp_region_h3 <-
   par_make_h3(
     nc,
-    res = 10L
+    res = 5L
   )
 plot(sf::st_geometry(nc_comp_region_h3))
 }

--- a/tests/testthat/test-gridding.R
+++ b/tests/testthat/test-gridding.R
@@ -443,19 +443,20 @@ testthat::test_that("par_make_h3 returns sf polygons with CGRIDID", {
   withr::local_package("h3r")
   pt <- st_sfc(st_point(c(18, -33)), crs = 4326)
   sf_pt <- st_sf(id = 1, geometry = pt)
+  ncp <- sf::st_read(system.file("shape/nc.shp", package = "sf"))
+  ncp <- sf::st_transform(ncp, "EPSG:4326")
 
-  # point geometry does not warn
-  h3_sf <- par_make_h3(sf_pt, res = 10L)
-  testthat::expect_s3_class(h3_sf, "sf")
-  testthat::expect_true("CGRIDID" %in% names(h3_sf))
-  testthat::expect_true(any(sf::st_geometry_type(h3_sf) == "POLYGON"))
+  # point geometry fails
+  testthat::expect_error(
+    h3_sf <- par_make_h3(sf_pt, res = 3L),
+    "Only polygon geometries are supported."
+  )
 
-  # polygon geometry warns
-  sf_pt <- st_buffer(sf_pt, dist = units::set_units(1000, "m"))
-  suppressWarnings(h3_sf <- par_make_h3(sf_pt, res = 10L))
-  testthat::expect_s3_class(h3_sf, "sf")
-  testthat::expect_true("CGRIDID" %in% names(h3_sf))
-  testthat::expect_true(any(sf::st_geometry_type(h3_sf) == "POLYGON"))
+  # polygon geometry
+  h3_ncsf <- par_make_h3(ncp, res = 3L)
+  testthat::expect_s3_class(h3_ncsf, "sf")
+  testthat::expect_true("CGRIDID" %in% names(h3_ncsf))
+  testthat::expect_true(any(sf::st_geometry_type(h3_ncsf) == "POLYGON"))
 
 })
 

--- a/tests/testthat/test-gridding.R
+++ b/tests/testthat/test-gridding.R
@@ -417,23 +417,27 @@ testthat::test_that("search_h3 returns correct H3 indices for sf input", {
   testthat::skip_if_not_installed("h3r")
   withr::local_package("sf")
   withr::local_package("h3r")
-  # Create a simple sf POINT
-  pt <- st_sfc(st_point(c(18, -33)), crs = 4326)
-  sf_pt <- st_sf(id = 1, geometry = pt)
-  res <- 10L
+
+  res <- 4L
+  ncp <- sf::st_read(system.file("shape/nc.shp", package = "sf"))
+  ncp <- sf::st_transform(ncp, "EPSG:4326")
   suppressWarnings(
-    h3_idx <- search_h3(sf_pt, res = res)
+    h3_idx <- search_h3(ncp, res = res)
   )
-  testthat::expect_type(h3_idx, "character")
-  testthat::expect_length(h3_idx, 1)
+  testthat::expect_type(h3_idx, "list")
+  testthat::expect_true(
+    all(is.character(unlist(h3_idx)))
+  )
 })
 
 
 testthat::test_that("search_h3 errors for non-sf input", {
   withr::local_package("sf")
   withr::local_package("h3r")
-  testthat::expect_error(search_h3(list(x = 1)),
-  "input should be sf or SpatVector object")
+  testthat::expect_error(
+    search_h3(list(x = 1)),
+    "input should be sf or SpatVector object"
+  )
 })
 
 testthat::test_that("par_make_h3 returns sf polygons with CGRIDID", {


### PR DESCRIPTION
- Fixes a bug in `par_make_h3` that retrieved H3 at polygon centroids
- `par_make_h3` and `make_h3` now only accept polygon geometries
- res = 3L is now the default resolution for `par_make_h3` and `make_h3`